### PR TITLE
refactor: enhance jsonResponse function with validation and error handling

### DIFF
--- a/examples/response.php
+++ b/examples/response.php
@@ -1,17 +1,52 @@
 <?php
-function jsonResponse($data = [], $status = 200, $message = '') {
-    http_response_code($status);
-    header('Content-Type: application/json');
-    echo json_encode([
+declare(strict_types=1);
+
+/**
+ * Generate a standardized JSON response.
+ *
+ * @param array|null $data   Response payload
+ * @param int        $status HTTP-like status code (100-599)
+ * @param string     $message Human-readable status message
+ *
+ * @return string JSON encoded response
+ *
+ * @throws InvalidArgumentException When inputs are invalid
+ * @throws RuntimeException         When encoding fails
+ */
+function jsonResponse($data = [], $status = 200, $message = ''): string
+{
+    if (!is_int($status) || $status < 100 || $status > 599) {
+        throw new InvalidArgumentException('Status must be a valid HTTP status code (100-599)');
+    }
+
+    if (!is_string($message)) {
+        throw new InvalidArgumentException('Message must be a string');
+    }
+
+    if ($data === null) {
+        $data = [];
+    }
+
+    if (!is_array($data)) {
+        throw new InvalidArgumentException('Data must be an array or null');
+    }
+
+    $response = [
         'status' => $status,
         'message' => $message,
-        'data' => $data
-    ], JSON_PRETTY_PRINT);
-    exit;
+        'data' => $data,
+    ];
+
+    $encoded = json_encode($response, JSON_PRETTY_PRINT);
+
+    if ($encoded === false) {
+        throw new RuntimeException('Failed to encode response as JSON');
+    }
+
+    return $encoded;
 }
 
-// Example usage
-if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {
-    jsonResponse(['user' => 'John'], 200, 'Success');
+// Example
+if (basename(__FILE__) === basename((string) ($_SERVER['SCRIPT_FILENAME'] ?? ''))) {
+    echo jsonResponse(['user' => 'John'], 200, 'Success') . PHP_EOL;
 }
-?>


### PR DESCRIPTION
- Aligned the PHP helper with the JS/Python behavior by returning the encoded payload and adding input validation so callers can decide whether to emit headers. 

- Reworked the PHP test harness to consume that return value, assert decoding, and cover validation/error scenarios end-to-end without relying on exit.